### PR TITLE
Add cstdlib for compilation on OS X

### DIFF
--- a/src/Translator.cpp
+++ b/src/Translator.cpp
@@ -8,6 +8,8 @@
 #include <algorithm>
 #include <cmath>
 
+#include <cstdlib>
+
 #include "Translator.h"
 
 using namespace std;


### PR DESCRIPTION
Hi,

Thanks for this wonderful resource.

I had problems compiling DeepCL on OS X Yosemite as it kept failing:

[  5%] Building CXX object CMakeFiles/DeepCL.dir/src/Translator.cpp.o
/Users/kennethban/Development/DeepCL/src/Translator.cpp:23:43: error: call to 'abs' is ambiguous
    const int rowCopyLength = imageSize - abs( translateCols );
                                          ^~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cmath:660:1: note: candidate function
abs(float __x) _NOEXCEPT {return fabsf(__x);}
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cmath:664:1: note: candidate function
abs(double __x) _NOEXCEPT {return fabs(__x);}
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cmath:668:1: note: candidate function
abs(long double __x) _NOEXCEPT {return fabsl(__x);}
^
1 error generated.

This was fixed by including the cstdlib for OS X

Thanks,
Kenneth