### PR TITLE
CMake config file and manifest txt loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,11 @@ unset(SWIG_EXECUTABLE CACHE)
 unset(SWIG_VERSION CACHE)
 unset(LUA_INCLUDE_DIR CACHE)
 
+if(BUILD_JPEG_SUPPORT)
+  set(LIBJPEG_AVAILABLE 1)
+  add_definitions( -DLIBJPEG_FOUND)
+endif(BUILD_JPEG_SUPPORT)
+
 # SET(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/dist" CACHE STRING "Installation directory." FORCE)
 
 SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
@@ -251,7 +256,43 @@ INSTALL(PROGRAMS src/activate.sh DESTINATION bin)
 INSTALL(PROGRAMS src/activate.bat DESTINATION bin)
 #INSTALL( DIRECTORY EasyCL/ DESTINATION include/easycl FILES_MATCHING PATTERN *.h )
 INSTALL( TARGETS DeepCL deepcl_train deepcl_predict deepcl_unittests deepcl_gtest
+    EXPORT DeepCLTargets
     RUNTIME DESTINATION bin
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib )
 
+# Generate the project config file.
+export(TARGETS DeepCL
+  FILE "${PROJECT_BINARY_DIR}/DeepCLTargets.cmake")
+export(PACKAGE DeepCL)
+
+if(WIN32 AND NOT CYGWIN)
+  set(DEF_INSTALL_CMAKE_DIR CMake)
+else()
+  set(DEF_INSTALL_CMAKE_DIR lib/cmake/DeepCL)
+endif()
+set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR})
+ 
+file(RELATIVE_PATH REL_INCLUDE_DIR "${CMAKE_INSTALL_PREFIX}/${INSTALL_CMAKE_DIR}"
+   "${CMAKE_INSTALL_PREFIX}/include")
+set(CONF_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/src/"
+  "${PROJECT_SOURCE_DIR}/EasyCL/"
+  "${PROJECT_SOURCE_DIR}/EasyCL/thirdparty/clew/include")
+set(ABS_LIBRARY_FILE "${PROJECT_BINARY_DIR}/libDeepCL.so" 
+  "${PROJECT_BINARY_DIR}/EasyCL/src/EasyCL-external-build/libEasyCL.so")
+if(APPLE)
+  set(ABS_LIBRARY_FILE "${PROJECT_BINARY_DIR}/libDeepCL.dylib" 
+    "${PROJECT_BINARY_DIR}/EasyCL/src/EasyCL-external-build/libEasyCL.dylib")
+endif(APPLE)
+configure_file(DeepCLConfig.cmake.in
+  "${PROJECT_BINARY_DIR}/DeepCLConfig.cmake" @ONLY)
+set(CONF_INCLUDE_DIRS "\${DEEPCL_CMAKE_DIR}/${REL_INCLUDE_DIR}"
+  "\${DEEPCL_CMAKE_DIR}/${REL_INCLUDE_DIR}/deepcl"
+  "\${DEEPCL_CMAKE_DIR}/${REL_INCLUDE_DIR}/easycl")
+set(ABS_LIBRARY_FILE "DeepCL" "EasyCL")
+configure_file(DeepCLConfig.cmake.in
+  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/DeepCLConfig.cmake" @ONLY)
+
+install(FILES
+  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/DeepCLConfig.cmake"
+  DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)

--- a/DeepCLConfig.cmake.in
+++ b/DeepCLConfig.cmake.in
@@ -1,0 +1,13 @@
+# - Config file for the DeepCL package
+# It defines the following variables
+#  DeepCL_INCLUDE_DIRS - include directories for DeepCL
+#  DeepCL_LIBRARIES    - libraries to link against
+ 
+get_filename_component(DEEPCL_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+set(DeepCL_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
+ 
+if(NOT TARGET DeepCL AND NOT DeepCL_BINARY_DIR)
+  include("${DEEPCL_CMAKE_DIR}/DeepCLTargets.cmake")
+endif()
+   
+set(DeepCL_LIBRARIES "@ABS_LIBRARY_FILE@")

--- a/test/mnist-to-jpegs.cpp
+++ b/test/mnist-to-jpegs.cpp
@@ -1,13 +1,13 @@
 // Copyright Hugh Perkins 2015 hughperkins at gmail
 //
-// This Source Code Form is subject to the terms of the Mozilla Public License, 
-// v. 2.0. If a copy of the MPL was not distributed with this file, You can 
+// This Source Code Form is subject to the terms of the Mozilla Public License,
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at http://mozilla.org/MPL/2.0/.
 
 // used to test loading jpegs from imagenet etc
 // this will take mnist dataset, and generate jpegs, in directories, one
 // directory per category, and an appropriate manifest file
-// when we read the images, we will assume all images have the same 
+// when we read the images, we will assume all images have the same
 // dimensions
 
 // note that the labels are part of the manifest, which will have the following
@@ -34,12 +34,12 @@ int main( int argc, char *argv[] ) {
     string mnistImagesFile = argv[1];
     string outDirectory = argv[2];
     int numExamples = atoi(argv[3]);
-    
+
     int N, planes, size;
-    GenericLoader::getDimensions( mnistImagesFile, &N, &planes, &size );
+    GenericLoader::getDimensions( mnistImagesFile.c_str(), &N, &planes, &size );
     float *imageData = new float[ N * planes * size * size ];
     int *labels = new int[N];
-    GenericLoader::load( mnistImagesFile, imageData, labels, 0, numExamples ); 
+    GenericLoader::load( mnistImagesFile.c_str(), imageData, labels, 0, numExamples );
 
     // now we've loaded the data, write it out in deepcl-jpeg-list-v1 format
     // we need to do the following:


### PR DESCRIPTION
In order to link against DeepCL using cmake's find_package function I added the generation of a cmake config file. Furthermore the loader for a manifest txt file was not enabled even though BUILD_JPEG_SUPPORT was set to ON. To enable manifests as input to deepcl_predict I changed the loader to GenericLoaderv2 in src/main/predict.cpp.