### PR TITLE
Installing DeepCLTargets.cmake with DeepCLConfig.cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,5 +301,8 @@ configure_file(DeepCLConfig.cmake.in
   "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/DeepCLConfig.cmake" @ONLY)
 
 install(FILES
+  "${PROJECT_BINARY_DIR}/DeepCLTargets.cmake"
+  DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
+install(FILES
   "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/DeepCLConfig.cmake"
   DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)


### PR DESCRIPTION
DeepCLTargets.cmake seems to be generated but not installed with DeepCLConfig.cmake. That leads to FIND_PACKAGE(DeepCL) not working because of the dependency between these files.