### PR TITLE
Added a substitute tanh function

### DIFF
--- a/cl/activate.cl
+++ b/cl/activate.cl
@@ -7,12 +7,16 @@
 // expected defines:
 // one of: [ TANH | RELU | LINEAR | SIGMOID | SCALEDTANH | ELU ]
 
-#define TANH_SUBSTITUTE(output) ((exp(output) - exp(-output)) / (exp(output) + exp(-output)))
+float tanh_substitute(float output) {
+  float pos = exp(output);
+  float neg = exp(-output);
+  return ((pos - neg) / (pos + neg));
+}
 
 #ifdef TANH
-    #define ACTIVATION_FUNCTION(output) (TANH_SUBSTITUTE(output))
+    #define ACTIVATION_FUNCTION(output) (tanh_substitute(output))
 #elif defined SCALEDTANH
-    #define ACTIVATION_FUNCTION(output) (1.7159f * TANH_SUBSTITUTE(0.66667f * output))
+    #define ACTIVATION_FUNCTION(output) (1.7159f * tanh_substitute(0.66667f * output))
 #elif SIGMOID
     #define ACTIVATION_FUNCTION(output) (1.0f / (1 + exp(-output)))
 #elif defined RELU

--- a/cl/activate.cl
+++ b/cl/activate.cl
@@ -7,10 +7,12 @@
 // expected defines:
 // one of: [ TANH | RELU | LINEAR | SIGMOID | SCALEDTANH | ELU ]
 
+#define TANH_SUBSTITUTE(output) ((exp(output) - exp(-output)) / (exp(output) + exp(-output)))
+
 #ifdef TANH
-    #define ACTIVATION_FUNCTION(output) (tanh(output))
+    #define ACTIVATION_FUNCTION(output) (TANH_SUBSTITUTE(output))
 #elif defined SCALEDTANH
-    #define ACTIVATION_FUNCTION(output) (1.7159f * tanh(0.66667f * output))
+    #define ACTIVATION_FUNCTION(output) (1.7159f * TANH_SUBSTITUTE(0.66667f * output))
 #elif SIGMOID
     #define ACTIVATION_FUNCTION(output) (1.0f / (1 + exp(-output)))
 #elif defined RELU


### PR DESCRIPTION
This is to avoid the tanh function which the Clover driver for OpenCL 1.1 doesn't seem to provide.