### PR TITLE
Fix activate.sh not working properly with spaces

### DIFF
--- a/src/activate.sh
+++ b/src/activate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 bin_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-dist_dir=$(dirname ${bin_dir})
+dist_dir="$(dirname "$bin_dir")"
 
 export PATH=${bin_dir}:$PATH
 


### PR DESCRIPTION
Fix activate.sh not working properly if white space is present in DeepCL's directory path(Ex: /home/marty/Documents/Machine Learning/dist)