### PR TITLE
Batcher: Prevent integer overflow when calculating batchStart

### DIFF
--- a/src/batch/Batcher.cpp
+++ b/src/batch/Batcher.cpp
@@ -89,8 +89,8 @@ PUBLICAPI bool Batcher::tick(int epoch) {
     }
     int batch = nextBatch;
 //    std::cout << "BatchLearner.tick() batch=" << batch << std::endl;
-    int batchStart = batch * batchSize;
-    int thisBatchSize = batchSize;
+    int64 batchStart = batch * batchSize;
+    int64 thisBatchSize = batchSize;
     if(batch == numBatches - 1) {
         thisBatchSize = N - batchStart;
     }

--- a/src/batch/Batcher2.cpp
+++ b/src/batch/Batcher2.cpp
@@ -85,8 +85,8 @@ bool Batcher2::tick(int epoch) {
     }
     int batch = nextBatch;
 //    std::cout << "BatchLearner.tick() batch=" << batch << std::endl;
-    int batchStart = batch * batchSize;
-    int thisBatchSize = batchSize;
+    int64 batchStart = batch * batchSize;
+    int64 thisBatchSize = batchSize;
     if(batch == numBatches - 1) {
         thisBatchSize = N - batchStart;
     }


### PR DESCRIPTION
After adding some more training data DeepCL started crashing during training, turns out `batch * batchSize` caused an integer overflow.

This PR fixes that by using a 64bit int instead of a 32bit one