### PR TITLE
Dropout Backprop Runtime Error Fix

### DIFF
--- a/src/dropout/DropoutLayer.cpp
+++ b/src/dropout/DropoutLayer.cpp
@@ -110,6 +110,7 @@ VIRTUAL void DropoutLayer::setBatchSize(int batchSize) {
     this->batchSize = batchSize;
     this->allocatedSize = batchSize;
     masks = new unsigned char[ getOutputNumElements() ];
+    generateMasks();
     maskWrapper = cl->wrap(getOutputNumElements(), masks);
     output = new float[ getOutputNumElements() ];
     outputWrapper = cl->wrap(getOutputNumElements(), output);


### PR DESCRIPTION
A runtime error was created when backprop was ran without first generating weights.

Placing `generateWeights()` with the variable declaration in `setBatchSize()` should always gaurentee that weights will be available.

Though, it is recommended to `net->setTraining(true)` before forward/back prop to ensure freshly generated weights each training input.