### PR TITLE
BackpropWeights.cpp: Revert re-ordering

### DIFF
--- a/src/conv/BackpropWeights.cpp
+++ b/src/conv/BackpropWeights.cpp
@@ -68,26 +68,26 @@ STATIC BackpropWeights *BackpropWeights::instanceSpecific(int idx, EasyCL *cl, L
         return new BackpropWeightsAuto(cl, layerDimensions);
     }
     if(idx == 0) {
-        return new BackpropWeightsNaive(cl, layerDimensions);
+        return new BackpropWeightsCpu(cl, layerDimensions);
     }
     if(idx == 1) {
-        return new BackpropWeightsScratch(cl, layerDimensions);
+        return new BackpropWeightsNaive(cl, layerDimensions);
     }
     if(idx == 2) {
-        return new BackpropWeightsScratchLarge(cl, layerDimensions);
+        return new BackpropWeightsScratch(cl, layerDimensions);
     }
     if(idx == 3) {
-        return new BackpropWeightsIm2Col(cl, layerDimensions);
+        return new BackpropWeightsScratchLarge(cl, layerDimensions);
     }
     if(idx == 4) {
+        return new BackpropWeightsIm2Col(cl, layerDimensions);
+    }
+    if (idx == 5) {
         return new BackpropWeightsFsword73(cl, layerDimensions);
     }
-	if (idx == 5) {
-		return new BackpropWeightsFsword73_BatchSize(cl, layerDimensions);
-	}
-	if (idx == 6) {
-		return new BackpropWeightsCpu(cl, layerDimensions);
-	}
+    if (idx == 6) {
+        return new BackpropWeightsFsword73_BatchSize(cl, layerDimensions);
+    }
 
     throw std::runtime_error("BackpropWeights::instanceSpecific doesnt handle idx " + toString(idx));
 }


### PR DESCRIPTION
Reverting the re-ordering that I missed from #131 